### PR TITLE
Treat an unreadable password hash as a failed comparison instead of throwing

### DIFF
--- a/user.js
+++ b/user.js
@@ -1535,7 +1535,19 @@ module.exports = Class.create({
 		// compare passwords for login, given plaintext, pw hash and user salt
 		if (this.config.get('use_bcrypt')) {
 			// use extremely secure but CPU expensive bcrypt algorithm
-			return bcrypt.compareSync(password + salt, hash);
+			// Note: compareSync() throws rather than returning false when the
+			// stored hash is absent, malformed, or was written in a bcrypt
+			// revision this library cannot parse.  Treat all of those as a
+			// failed comparison, so that one bad user record cannot take down
+			// the whole process by way of an uncaught exception.
+			try {
+				return bcrypt.compareSync(password + salt, hash);
+			}
+			catch (err) {
+				// some bcrypt implementations throw a bare string, not an Error
+				this.logError('login', "Password hash comparison failed: " + (err.message || err));
+				return false;
+			}
 		}
 		else {
 			// use weaker but fast salted SHA-256 algorithm


### PR DESCRIPTION
### Problem

`comparePasswords()` hands the stored hash straight to `compareSync()` with no error handling:

```js
return bcrypt.compareSync(password + salt, hash);
```

`compareSync()` doesn't return `false` for a hash it can't parse, it throws. So a user record whose `password` field is missing, truncated, or written in a bcrypt revision the linked library can't read raises an exception out of `api_login()` instead of failing the login. That's uncaught in a pixl-server app, so the process goes down, and since the record is persisted it goes down again on every retry.

With bcryptjs 3.0.3 on node 22, `compareSync(pw, undefined)` throws `Illegal arguments: string, undefined`. On the 1.x line, which links bcrypt-node 0.1.0, a `$2b$` hash throws the bare string `"Invalid salt revision"`, so there's no `.message` or stack to go on.

I hit this through Cronicle, which pins `^1.0.34` and writes `$2b$` hashes with bcryptjs from its own CLI. Sorting out that mismatch is Cronicle's problem, not yours. This is only about the failure mode: a record we can't verify should fail the login, not the process.

### Fix

Wrap the compare, log why, return false.

- `err.message || err` is deliberate, since bcryptjs throws an `Error` and bcrypt-node throws a string.
- Nothing changes for any input that already returned a value. The only paths affected are ones that currently kill the process.
- Covers all three call sites. The non-bcrypt branch already returns `false` for a hash it can't match, so this brings the bcrypt branch in line.
- `node --check` passes.

### Noticed while in there

`api_login()` compares first to prevent timing attacks, but for an unknown user it passes `Tools.generateUniqueID()` where a hash goes. `compareSync()` rejects that on a parse check without running the KDF, so the unknown-user path returns much faster than the known-user one. Comparing against a precomputed dummy hash would close it. Happy to send that separately.
